### PR TITLE
Dynamic series object name

### DIFF
--- a/appserver/static/visualizations/hman/src/buildCustomOption/index.js
+++ b/appserver/static/visualizations/hman/src/buildCustomOption/index.js
@@ -87,7 +87,7 @@ const _buildCustomOption = function (data, config) {
       tmpSeriesObj = cloneDeep(dynamicSeriesTemplate);
       tmpNameIterator += 1;
       if(typeof tmpSeriesObj.name === 'undefined' || tmpSeriesObj.name === '') {
-        tmpSeriesObj.name = `DynamicSeries ${tmpNameIterator}`;
+        tmpSeriesObj.name = data.fields[theProcessedSeries[i]].name || `DynamicSeries ${tmpNameIterator}`;
       } else {
         tmpSeriesObj.name += ` ${tmpNameIterator}`;
       }


### PR DESCRIPTION
If set the dynamic  series like this:
`<option name="visualization_toolbox.hman.seriesDataIndexBinding">1*</option>`
the series name is only set with the DynamicSeries* template and does not use the series name from the given data

Now the  series name is set from the given data, now you able to set an wildcard for the seriesDataIndexBinding and get to show all dataseries with the series name from the given data.
