### PR TITLE
cache burst, sane defaults for grid and dataZoom, backwards compatibility changes for legend, npm audit fixes

### DIFF
--- a/.github/workflows/build_and_package_app.yml
+++ b/.github/workflows/build_and_package_app.yml
@@ -79,10 +79,10 @@ jobs:
          cd appserver/static/visualizations/hman
          npm fund
 
-    - name: npm audit without transitive deps
+    - name: npm audit
       run: |
          cd appserver/static/visualizations/hman
-         npm audit audit --omit=dev
+         npm audit fix --force
 
     - name: Clean node-modules
       run: | 

--- a/.github/workflows/release_app.yml
+++ b/.github/workflows/release_app.yml
@@ -59,10 +59,10 @@ jobs:
       run: |
          cd appserver/static/visualizations/hman
          npm fund
-    - name: npm audit without transitive deps
+    - name: npm audit
       run: |
          cd appserver/static/visualizations/hman
-         npm audit audit --omit=dev
+         npm audit fix --force
 
     - name: Clean node-modules
       run: | 

--- a/app.manifest
+++ b/app.manifest
@@ -5,12 +5,17 @@
     "id": {
       "group": null,
       "name": "visualization_toolbox",
-      "version": "0.4.4"
+      "version": "0.4.5-rc1"
     },
     "author": [
       {
         "name": "Bjoern Hamann",
         "email": null,
+        "company": null
+      },
+      {
+        "name": "Octavian Cioaca",
+        "email": "work@selardi.com",
         "company": null
       }
     ],

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "visualization_toolbox",
-      "version": "0.4.5-rc1"
+      "version": "0.4.5-rc2"
     },
     "author": [
       {

--- a/appserver/static/visualizations/hman/package-lock.json
+++ b/appserver/static/visualizations/hman/package-lock.json
@@ -1332,9 +1332,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/appserver/static/visualizations/hman/package-lock.json
+++ b/appserver/static/visualizations/hman/package-lock.json
@@ -14,7 +14,7 @@
         "lodash.clonedeep": "^4.5.0",
         "lodash.find": "^4.6.0",
         "mqtt": "5.7.1",
-        "underscore": "1.13.6"
+        "underscore": "^1.13.8"
       },
       "devDependencies": {
         "@eslint/js": "9.0.0",
@@ -1105,9 +1105,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1765,16 +1765,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2068,16 +2068,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -2197,16 +2187,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shallow-clone": {
@@ -2351,16 +2331,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -2411,9 +2390,9 @@
       "license": "MIT"
     },
     "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/undici-types": {

--- a/appserver/static/visualizations/hman/package.json
+++ b/appserver/static/visualizations/hman/package.json
@@ -25,6 +25,6 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.find": "^4.6.0",
     "mqtt": "5.7.1",
-    "underscore": "1.13.6"
+    "underscore": "^1.13.8"
   }
 }

--- a/appserver/static/visualizations/hman/src/buildTimelineOption/index.js
+++ b/appserver/static/visualizations/hman/src/buildTimelineOption/index.js
@@ -536,12 +536,7 @@ const _buildTimelineOption = function (data, config, tmpChartInstance) {
 
   if (!optionFromXmlDashboard.legend) {
     computedOption.legend = {
-      ...computedOption.legend,
-      textStyle: {
-        color: genericTextColor,
-        fontSize: 13,
-      },
-      top: 30
+      ...computedOption.legend
     }
   } else {
     // Merge properties from optionFromXmlDashboard.legend into computedOption.legend
@@ -705,6 +700,7 @@ const _buildTimelineOption = function (data, config, tmpChartInstance) {
       computedOption[tmpOptionKey] = optionFromXmlDashboard[tmpOptionKey];
     }
   }
+  console.log('Before returning the computed option...');
   return computedOption;
 }
 

--- a/appserver/static/visualizations/hman/src/buildTimelineOption/index.js
+++ b/appserver/static/visualizations/hman/src/buildTimelineOption/index.js
@@ -394,14 +394,20 @@ const _buildTimelineOption = function (data, config, tmpChartInstance) {
   // Ensure grid property overwrite
   const visualizationHeight = splitByHour ? (35 * yAxisListedHours.length) : (70 * processedCategories.length);
 
+  this.scopedVariables['visualizationHeight'] = visualizationHeight + 130;
   if (!optionFromXmlDashboard.grid) {
     // Apply default setting for echart option.grid
-    this.scopedVariables['visualizationHeight'] = visualizationHeight + 130;
     computedOption.grid = {
       height: visualizationHeight,
       left: '5%',
       top: 80,
       containLabel: true,
+    };
+  } else {
+    // Merge custom grid but enforce the computed height to keep rectangle sizing consistent
+    computedOption.grid = {
+      ...optionFromXmlDashboard.grid,
+      height: visualizationHeight,
     };
   }
 

--- a/appserver/static/visualizations/hman/src/buildTimelineOption/index.js
+++ b/appserver/static/visualizations/hman/src/buildTimelineOption/index.js
@@ -401,6 +401,7 @@ const _buildTimelineOption = function (data, config, tmpChartInstance) {
       height: visualizationHeight,
       left: '5%',
       top: 80,
+      bottom: 44,
       containLabel: true,
     };
   } else {
@@ -408,13 +409,17 @@ const _buildTimelineOption = function (data, config, tmpChartInstance) {
     computedOption.grid = {
       ...optionFromXmlDashboard.grid,
       height: visualizationHeight,
+      left: optionFromXmlDashboard.grid.left ?? '5%',
+      top: optionFromXmlDashboard.grid.top ?? 80,
+      bottom: optionFromXmlDashboard.grid.bottom ?? 44,
+      containLabel: optionFromXmlDashboard.grid.containLabel ?? true,
     };
   }
 
   // Ensure dataZoom property overwrite
   if (!optionFromXmlDashboard.dataZoom && !splitByHour) {
     // Apply default setting for echart option.dataZoom, but only when splitByHour is not active
-    const dataZoomTopPosition = this.scopedVariables['visualizationHeight'] - 40; //40 is the estimated height of the dataZoom slider bar
+    const dataZoomTopPosition = this.scopedVariables['visualizationHeight'] - 44; //40 is the estimated height of the dataZoom slider bar
     computedOption.dataZoom = [
       {
         type: 'slider',
@@ -700,8 +705,8 @@ const _buildTimelineOption = function (data, config, tmpChartInstance) {
 
   // Overwrite the option keys with values from the xml dashboard
   for (var tmpOptionKey in optionFromXmlDashboard) {
-    // Check if the tmpOptionKey is not 'yAxis' or 'series' or 'legend' and if optionFromXmlDashboard has the tmpOptionKey
-    if (tmpOptionKey !== 'yAxis' && tmpOptionKey !== 'series' && tmpOptionKey !== 'legend' && Object.prototype.hasOwnProperty.call(optionFromXmlDashboard, tmpOptionKey)) {
+    // Check if the tmpOptionKey is not 'yAxis' or 'series', 'legend' or 'grid' and if optionFromXmlDashboard has the tmpOptionKey
+    if (tmpOptionKey !== 'yAxis' && tmpOptionKey !== 'series' && tmpOptionKey !== 'legend' && tmpOptionKey !== 'grid' && Object.prototype.hasOwnProperty.call(optionFromXmlDashboard, tmpOptionKey)) {
       // Replace the value in option with the value from optionFromXmlDashboard
       computedOption[tmpOptionKey] = optionFromXmlDashboard[tmpOptionKey];
     }

--- a/appserver/static/visualizations/hman/src/updateView/index.js
+++ b/appserver/static/visualizations/hman/src/updateView/index.js
@@ -97,6 +97,17 @@ const _updateView = function (data, config) {
       fontFamily: "Splunk Platform Sans"
     }
   }
+
+  // Overwrite default eCharts v6 legend position
+  if (typeof option.legend === 'undefined' || (typeof option.legend.top === 'undefined' && typeof option.legend.bottom === 'undefined')) {
+    if (typeof option.legend === 'undefined') {
+      option.legend = {};
+    }
+    option.legend.top = 0;
+  }
+
+  console.log('He we apply the magical option...');
+
   tmpChart['instanceByDom'].setOption(option);
   tmpChart['_option'] = option;
   

--- a/appserver/static/visualizations/hman/src/updateView/index.js
+++ b/appserver/static/visualizations/hman/src/updateView/index.js
@@ -106,8 +106,6 @@ const _updateView = function (data, config) {
     option.legend.top = 0;
   }
 
-  console.log('He we apply the magical option...');
-
   tmpChart['instanceByDom'].setOption(option);
   tmpChart['_option'] = option;
   

--- a/default/app.conf
+++ b/default/app.conf
@@ -4,10 +4,10 @@
 
 [id]
 name = visualization_toolbox
-version = 0.4.5-rc1
+version = 0.4.5-rc2
 
 [install]
-build = 0.4.5-rc1
+build = 0.4.5-rc2
 state = enabled
 is_configured = 0
 
@@ -23,7 +23,7 @@ company = hman
 [launcher]
 author = hman
 description = Visualization Toolbox for Splunk Enterprise powered by the Apache ECharts library.
-version = 0.4.5-rc1
+version = 0.4.5-rc2
 
 [package]
 check_for_updates = 1

--- a/default/app.conf
+++ b/default/app.conf
@@ -7,7 +7,7 @@ name = visualization_toolbox
 version = 0.4.5-rc1
 
 [install]
-build = replacebuild
+build = 0.4.5-rc1
 state = enabled
 is_configured = 0
 

--- a/default/app.conf
+++ b/default/app.conf
@@ -4,7 +4,7 @@
 
 [id]
 name = visualization_toolbox
-version = 0.4.4
+version = 0.4.5-rc1
 
 [install]
 build = replacebuild
@@ -23,7 +23,7 @@ company = hman
 [launcher]
 author = hman
 description = Visualization Toolbox for Splunk Enterprise powered by the Apache ECharts library.
-version = 0.4.4
+version = 0.4.5-rc1
 
 [package]
 check_for_updates = 1


### PR DESCRIPTION
- enforce cache burst on splunk for static assets of the visualization_toolbox
- keep sane default for grid positioning and dataZoom positioning in timeline mode
- enable backwards compatibility to v5.6 of eCharts for legend positioning
- npm audit fixes and github workflows patches
