### PR TITLE
Timeline visualization and github CI updates

### DIFF
--- a/.github/workflows/build_and_package_app.yml
+++ b/.github/workflows/build_and_package_app.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main", "test" ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
 
@@ -13,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     outputs:
@@ -26,14 +29,12 @@ jobs:
       
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-    
+      uses: actions/checkout@v4.2.2
+
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4.4.0
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-        cache-dependency-path: './appserver/static/visualizations/hman/package-lock.json'
 
     # Write app version and workflow id to variables for later usage
     - name: Version information
@@ -56,7 +57,7 @@ jobs:
            echo "Tar.gz name: $tar_name"
            echo "tar_name=$tar_name" >> $GITHUB_OUTPUT
 
-    - name: NPM install 
+    - name: NPM install
       run: |
            cd appserver/static/visualizations/hman
            npm install
@@ -65,9 +66,6 @@ jobs:
       run: |
         cd appserver/static/visualizations/hman
         npm run build
-
-    - name: upgrade version  
-      run: npm install npm@latest -g  
 
     - name: npm update
       run: |
@@ -125,7 +123,7 @@ jobs:
        
        
     - name: install python 3.9
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v5.6.0
       with: 
        python-version: '3.9'     
 

--- a/.github/workflows/release_app.yml
+++ b/.github/workflows/release_app.yml
@@ -1,6 +1,9 @@
 name: ReleaseApp
 on:
   workflow_dispatch:
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-24.04
@@ -15,14 +18,12 @@ jobs:
       slim_package_name: ${{ steps.package_app.outputs.slim_package_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-    
+      uses: actions/checkout@v4.2.2
+
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4.4.0
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-        cache-dependency-path: './appserver/static/visualizations/hman/package-lock.json'
     # Write app version and workflow id to variables for later usage
     - name: Version information
       id: version_information
@@ -40,7 +41,7 @@ jobs:
            tar_name="visualization_toolbox-$app_version.tar.gz"
            echo "Tar.gz name: $tar_name"
            echo "tar_name=$tar_name" >> $GITHUB_OUTPUT
-    - name: NPM install 
+    - name: NPM install
       run: |
            cd appserver/static/visualizations/hman
            npm install
@@ -48,8 +49,6 @@ jobs:
       run: |
         cd appserver/static/visualizations/hman
         npm run build
-    - name: upgrade version  
-      run: npm install npm@latest -g  
       
     - name: npm update
       run: |
@@ -72,7 +71,7 @@ jobs:
       run: |
           sed -i -e "s/replacebuild/${{ steps.version_information.outputs.build_number }}/g" default/app.conf  
     - name: install python 3.9
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v5.6.0
       with: 
        python-version: '3.9'     
     - name: install packaging toolkit CLI

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ lookups/timeline_by_hour_10_jan_2025.csv
 lookups/two_machines.csv
 lookups/timeline_by_hour_data.csv
 lookups/timeline_by_machine.csv
+.codex

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 .claude
+*.js.map
 
 # Local files
 metadata

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "visualization_toolbox",
-      "version": "0.4.6"
+      "version": "0.4.7-rc6"
     },
     "author": [
       {

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "visualization_toolbox",
-      "version": "0.4.7-rc6"
+      "version": "0.4.7"
     },
     "author": [
       {

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "visualization_toolbox",
-      "version": "0.4.8-rc3"
+      "version": "0.4.8"
     },
     "author": [
       {

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "visualization_toolbox",
-      "version": "0.4.8-rc1"
+      "version": "0.4.8-rc2"
     },
     "author": [
       {

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "visualization_toolbox",
-      "version": "0.4.8-rc2"
+      "version": "0.4.8-rc3"
     },
     "author": [
       {

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "visualization_toolbox",
-      "version": "0.4.7"
+      "version": "0.4.8-rc1"
     },
     "author": [
       {

--- a/appserver/static/visualizations/hman/package.json
+++ b/appserver/static/visualizations/hman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spc",
-  "version": "1.0.0",
+  "version": "0.4.7-rc6",
   "description": "ECharts visualization for splunk",
   "main": "visualization.js",
   "scripts": {

--- a/appserver/static/visualizations/hman/package.json
+++ b/appserver/static/visualizations/hman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spc",
-  "version": "0.4.8-rc3",
+  "version": "0.4.8",
   "description": "ECharts visualization for splunk",
   "main": "visualization.js",
   "scripts": {

--- a/appserver/static/visualizations/hman/package.json
+++ b/appserver/static/visualizations/hman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spc",
-  "version": "0.4.7-rc6",
+  "version": "0.4.7",
   "description": "ECharts visualization for splunk",
   "main": "visualization.js",
   "scripts": {

--- a/appserver/static/visualizations/hman/package.json
+++ b/appserver/static/visualizations/hman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spc",
-  "version": "0.4.8-rc1",
+  "version": "0.4.8-rc2",
   "description": "ECharts visualization for splunk",
   "main": "visualization.js",
   "scripts": {

--- a/appserver/static/visualizations/hman/package.json
+++ b/appserver/static/visualizations/hman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spc",
-  "version": "0.4.8-rc2",
+  "version": "0.4.8-rc3",
   "description": "ECharts visualization for splunk",
   "main": "visualization.js",
   "scripts": {

--- a/appserver/static/visualizations/hman/package.json
+++ b/appserver/static/visualizations/hman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spc",
-  "version": "0.4.7",
+  "version": "0.4.8-rc1",
   "description": "ECharts visualization for splunk",
   "main": "visualization.js",
   "scripts": {

--- a/appserver/static/visualizations/hman/src/buildCustomOption/index.js
+++ b/appserver/static/visualizations/hman/src/buildCustomOption/index.js
@@ -201,10 +201,10 @@ const _buildCustomOption = function (data, config) {
         var highPoint = api.coord([xValue, api.value(1)]);
         var lowPoint = api.coord([xValue, api.value(2)]);
         var halfWidth = api.size([1, 0])[0] * 0.1;
-        var style = api.style({
+        var style = {
           stroke: api.visual('color'),
           fill: null
-        });
+        };
 
         return {
           type: 'group',

--- a/appserver/static/visualizations/hman/src/buildTimelineOption/index.js
+++ b/appserver/static/visualizations/hman/src/buildTimelineOption/index.js
@@ -1,132 +1,116 @@
 const SplunkVisualizationUtils = require('api/SplunkVisualizationUtils');
 const echarts = require('echarts');
 const lodashFind = require('lodash.find');
+const { resolvePixelValue } = require('../timelineLayoutUtils');
 
-let processedData = [];
-let optionFromXmlDashboard = {};
-let processedLegends = [];
-let manuallyAddedLegends = [];
-let manuallySelectedLegends = {};
-let processedCategories = [];
 let tmpLocaleOption = 'en-GB';
-let xAxisDataMinValue = '';
-let xAxisDataMaxValue = '';
-let xAxisStartDates = [];
-let yAxisListedHours = [];
-let hourlyIntervals = [];
-let bandHeight = 32;
-let bandGap = 8;
 if (typeof window._i18n_locale !== 'undefined' && typeof window._i18n_locale.locale_name !== 'undefined') {
   tmpLocaleOption = window._i18n_locale.locale_name.replace('_', '-');
 }
 
-function reInitializeDataHolders() {
-  processedData = [];
-  optionFromXmlDashboard = {};
-  processedLegends = [];
-  manuallyAddedLegends = [];
-  manuallySelectedLegends = {};
-  processedCategories = [];
-  xAxisDataMinValue = '';
-  xAxisDataMaxValue = '';
-  xAxisStartDates = [];
-  yAxisListedHours = [];
-  hourlyIntervals = [];
-  bandHeight = 32;
-  bandGap = 8;
+function resolveOptionalIntegerConfig(value, fallbackValue, propertyName, minimumValue) {
+  if (value === undefined || value === null || value === '') {
+    return fallbackValue;
+  }
+
+  const parsedValue = Number.parseInt(value, 10);
+  if (Number.isInteger(parsedValue) && parsedValue >= minimumValue) {
+    return parsedValue;
+  }
+
+  console.log(`Warning! The ${propertyName} property must be an integer greater than or equal to ${minimumValue}. The current value is not correct and was replaced with the default value.`);
+  return fallbackValue;
 }
 
-function renderItemForHour(params, api) {
-  // 1. Initialize the counter on the context object
-  if (params.context.counter === undefined) {
-    params.context.counter = 0;
-  }
-
-  // Use params.dataIndex to get the full data item
-  const eventItemData = processedData[params.dataIndex];
-  if (!eventItemData) {
-    return;
-  }
-
-  // Get the event start and end timestamps in seconds
-  let tmpEventDurationInSeconds = eventItemData.eventDurationInSeconds;
-  // Get the corresponding yAxisIndexes from the matchedHourlyIntervals the event belongs to
-  const yAxisIndexes = eventItemData.matchedHourlyIntervals;
-  const tmpStartDate = new Date(eventItemData.value[0])
-  const tmpEventStartMinute = new Intl.DateTimeFormat(tmpLocaleOption, {
-    minute: "2-digit",
-  }).format(tmpStartDate);
-  let tmpEventStartPoint = tmpEventStartMinute * 60;
-  let tmpMaximumInitialDrawingSpace = 3600 - (tmpEventStartMinute * 60);
-  let yAxisDownIterator = 0;
-  let rectangleDrawingsArray = [];
-  while (tmpEventDurationInSeconds > 0) {
-    // Get the start point for drawing the rectangles
-    // Use api.coord to get the pixel coordinates for the rectangle.
-    const pointStart = api.coord([tmpEventStartPoint, yAxisIndexes[yAxisDownIterator]]);
-    const pointEnd = api.coord([tmpEventStartPoint + tmpMaximumInitialDrawingSpace, yAxisIndexes[yAxisDownIterator]]);
-    var slotHeight = api.size([0, 1])[1]; // pixel height of one category slot
-    var drawHeight = slotHeight - bandGap;
-    const rectShape = {
-      x: pointStart[0],
-      y: pointStart[1] - drawHeight / 2,
-      width: pointEnd[0] - pointStart[0],
-      height: drawHeight,
-    };
-    const rectDrawing = {
-      type: 'rect',
-      shape: rectShape,
-      style: api.style(),
-    };
-    rectangleDrawingsArray.push(rectDrawing);
-    tmpEventStartPoint = 0; // Start from zero on the next row
-    tmpEventDurationInSeconds = tmpEventDurationInSeconds - tmpMaximumInitialDrawingSpace;
-    tmpMaximumInitialDrawingSpace = tmpEventDurationInSeconds;
-    if (tmpMaximumInitialDrawingSpace > 3600) {
-      tmpMaximumInitialDrawingSpace = 3600; // Restrict the max nr of drawed seconds per line
+function makeRenderItemForHour(bandHeight, processedData) {
+  return function renderItemForHour(params, api) {
+    // 1. Initialize the counter on the context object
+    if (params.context.counter === undefined) {
+      params.context.counter = 0;
     }
-    yAxisDownIterator++
-  }
-  params.context.counter++;
-  return {
-    type: 'group',
-    children: rectangleDrawingsArray,
+
+    // Use params.dataIndex to get the full data item
+    const eventItemData = processedData[params.dataIndex];
+    if (!eventItemData) {
+      return;
+    }
+
+    // Get the event start and end timestamps in seconds
+    let tmpEventDurationInSeconds = eventItemData.eventDurationInSeconds;
+    // Get the corresponding yAxisIndexes from the matchedHourlyIntervals the event belongs to
+    const yAxisIndexes = eventItemData.matchedHourlyIntervals;
+    const tmpStartDate = new Date(eventItemData.value[0])
+    const tmpEventStartMinute = new Intl.DateTimeFormat(tmpLocaleOption, {
+      minute: "2-digit",
+    }).format(tmpStartDate);
+    let tmpEventStartPoint = tmpEventStartMinute * 60;
+    let tmpMaximumInitialDrawingSpace = 3600 - (tmpEventStartMinute * 60);
+    let yAxisDownIterator = 0;
+    let rectangleDrawingsArray = [];
+    while (tmpEventDurationInSeconds > 0) {
+      // Get the start point for drawing the rectangles
+      // Use api.coord to get the pixel coordinates for the rectangle.
+      const pointStart = api.coord([tmpEventStartPoint, yAxisIndexes[yAxisDownIterator]]);
+      const pointEnd = api.coord([tmpEventStartPoint + tmpMaximumInitialDrawingSpace, yAxisIndexes[yAxisDownIterator]]);
+      const rectShape = {
+        x: pointStart[0],
+        y: pointStart[1] - bandHeight / 2,
+        width: pointEnd[0] - pointStart[0],
+        height: bandHeight,
+      };
+      const rectDrawing = {
+        type: 'rect',
+        shape: rectShape,
+        style: { fill: api.visual('color') },
+      };
+      rectangleDrawingsArray.push(rectDrawing);
+      tmpEventStartPoint = 0; // Start from zero on the next row
+      tmpEventDurationInSeconds = tmpEventDurationInSeconds - tmpMaximumInitialDrawingSpace;
+      tmpMaximumInitialDrawingSpace = tmpEventDurationInSeconds;
+      if (tmpMaximumInitialDrawingSpace > 3600) {
+        tmpMaximumInitialDrawingSpace = 3600; // Restrict the max nr of drawed seconds per line
+      }
+      yAxisDownIterator++
+    }
+    params.context.counter++;
+    return {
+      type: 'group',
+      children: rectangleDrawingsArray,
+    };
   };
 }
 
-function renderItemLogic(params, api) {
-  var categoryIndex = api.value(2);
-  var start = api.coord([api.value(0), categoryIndex]);
-  var end = api.coord([api.value(1), categoryIndex]);
-  var slotHeight = api.size([0, 1])[1]; // pixel height of one category slot
-  var drawHeight = slotHeight - bandGap;
-  var rectShape = echarts.graphic.clipRectByRect(
-    {
-      x: start[0],
-      y: start[1] - drawHeight / 2,
-      width: end[0] - start[0],
-      height: drawHeight
-    },
-    {
-      x: params.coordSys.x,
-      y: params.coordSys.y,
-      width: params.coordSys.width,
-      height: params.coordSys.height
-    }
-  );
-  return (
-    rectShape && {
-      type: 'rect',
-      transition: ['shape'],
-      shape: rectShape,
-      style: api.style(),
-      styleEmphasis: api.styleEmphasis(),
-    }
-  );
+function makeRenderItemLogic(bandHeight) {
+  return function renderItemLogic(params, api) {
+    var categoryIndex = api.value(2);
+    var start = api.coord([api.value(0), categoryIndex]);
+    var end = api.coord([api.value(1), categoryIndex]);
+    var rectShape = echarts.graphic.clipRectByRect(
+      {
+        x: start[0],
+        y: start[1] - bandHeight / 2,
+        width: end[0] - start[0],
+        height: bandHeight
+      },
+      {
+        x: params.coordSys.x,
+        y: params.coordSys.y,
+        width: params.coordSys.width,
+        height: params.coordSys.height
+      }
+    );
+    return (
+      rectShape && {
+        type: 'rect',
+        transition: ['shape'],
+        shape: rectShape,
+        style: { fill: api.visual('color') },
+      }
+    );
+  };
 }
 
 const _buildTimelineOption = function (data, config, tmpChartInstance, tmpChart) {
-  reInitializeDataHolders();
   const currentTheme = SplunkVisualizationUtils.getCurrentTheme();
   const genericTextColor = currentTheme === 'dark' ? '#fff' : '#000';
   // Start creating the annotated computedOption object that will be passed to echart instance
@@ -135,19 +119,19 @@ const _buildTimelineOption = function (data, config, tmpChartInstance, tmpChart)
   let configOption = config[this.getPropertyNamespaceInfo().propertyNamespace + "option"];
   let useSplunkCategoricalColors = config[this.getPropertyNamespaceInfo().propertyNamespace + "timeline_useSplunkCategoricalColors"] || 'false';
   let splitByHour = config[this.getPropertyNamespaceInfo().propertyNamespace + "timeline_splitByHour"];
-  let _private_bandHeight = parseInt(config[this.getPropertyNamespaceInfo().propertyNamespace + "timeline_bandHeight"]);
-  let _private_bandGap = parseInt(config[this.getPropertyNamespaceInfo().propertyNamespace + "timeline_bandGap"]);
+  let _private_bandHeight = config[this.getPropertyNamespaceInfo().propertyNamespace + "timeline_bandHeight"];
+  let _private_bandGap = config[this.getPropertyNamespaceInfo().propertyNamespace + "timeline_bandGap"];
   if (typeof splitByHour !== 'undefined' && splitByHour === 'true') {
     splitByHour = true;
   } else {
     splitByHour = false;
   }
 
-  optionFromXmlDashboard = this._parseOption(configOption);
+  const optionFromXmlDashboard = this._parseOption(configOption);
   const _setCustomTokens = this._setCustomTokens;
   const _setSplunkMessages = this._setSplunkMessages;
 
-  // Extract 
+  // Extract
   let computedDimensions = data.fields.map(tmpField => tmpField.name);
   let allSeriesData = [];
   let deselectedLegends = []; // Array to track deselected legends
@@ -195,6 +179,17 @@ const _buildTimelineOption = function (data, config, tmpChartInstance, tmpChart)
       value !== "" && value !== null && value !== undefined
     )
   );
+
+  let processedData = [];
+  let processedLegends = [];
+  let manuallyAddedLegends = [];
+  let manuallySelectedLegends = {};
+  let processedCategories = [];
+  let xAxisDataMinValue = '';
+  let xAxisDataMaxValue = '';
+  let xAxisStartDates = [];
+  let yAxisListedHours = [];
+  let hourlyIntervals = [];
 
   if (useSplunkCategoricalColors.toLowerCase() === 'true') {
     // Get all unique categories from cleanDataRows
@@ -284,8 +279,7 @@ const _buildTimelineOption = function (data, config, tmpChartInstance, tmpChart)
 
     let rawEventsStartTime = this.scopedVariables['timeRange']['earliest'];
     let rawEventsEndTime = this.scopedVariables['timeRange']['latest'];
-    
-    hourlyIntervals = [];
+
     yAxisListedHours = this._sharedFunctions.getHourlyIntervals(rawEventsStartTime, rawEventsEndTime);
     if(yAxisListedHours.length > 25) {
       _setSplunkMessages("error", "The time range is too large. This visualization is adapted only for maximum 24 hourly intervals. The rest of the data has been trimmed. Try removing splitByHour parameter?");
@@ -399,25 +393,18 @@ const _buildTimelineOption = function (data, config, tmpChartInstance, tmpChart)
     return null;
   }
 
-  if(Number.isInteger(_private_bandHeight)) {
-    bandHeight = _private_bandHeight;
-  } else {
-    console.log('Warning! The timeline_bandHeight property must be an integer. The current values is not correct and was replaced with a default value.');
-  }
-  if(Number.isInteger(_private_bandGap)) {
-    bandGap = _private_bandGap;
-  } else {
-    console.log('Warning! The timeline_bandGap property must be an integer. The current values is not correct and was replaced with a default value.');
-  }
+  const bandHeight = resolveOptionalIntegerConfig(_private_bandHeight, 32, 'timeline_bandHeight', 1);
+  const bandGap = resolveOptionalIntegerConfig(_private_bandGap, 8, 'timeline_bandGap', 0);
+
   // Ensure grid property overwrite
-  const visualizationHeight = splitByHour ? ((bandHeight + bandGap) * yAxisListedHours.length) : ((bandHeight + bandGap) * processedCategories.length);
-  tmpChart['visualizationHeight'] = visualizationHeight + 210;
+  const visualizationGridHeight = splitByHour ? ((bandHeight + bandGap) * yAxisListedHours.length) : ((bandHeight + bandGap) * processedCategories.length);
   if (!optionFromXmlDashboard.grid) {
     computedOption.grid = {
       left: 160,
       top: 80,
       bottom: 80,
       right: 20,
+      height: visualizationGridHeight,
       containLabel: false,
     };
   } else {
@@ -427,14 +414,18 @@ const _buildTimelineOption = function (data, config, tmpChartInstance, tmpChart)
       top: optionFromXmlDashboard.grid.top ?? 80,
       bottom: optionFromXmlDashboard.grid.bottom ?? 80,
       right: optionFromXmlDashboard.grid.right ?? 20,
+      height: optionFromXmlDashboard.grid.height ?? visualizationGridHeight,
       containLabel: false,
     };
   }
 
+  const gridTop = resolvePixelValue(computedOption.grid.top, 80);
+  const gridBottom = resolvePixelValue(computedOption.grid.bottom, 80);
+  const resolvedGridHeight = resolvePixelValue(computedOption.grid.height, visualizationGridHeight);
+
   // Ensure dataZoom property overwrite
   if (!splitByHour && optionFromXmlDashboard.dataZoom) {
-    const gridBottom = (computedOption.grid && computedOption.grid.bottom) ? computedOption.grid.bottom : 50;
-    const dataZoomTopPosition = 80 + visualizationHeight + gridBottom; // position dataZoom below the grid and xAxis labels (top offset + grid height + bottom margin)
+    const dataZoomTopPosition = gridTop + resolvedGridHeight + 30; // position dataZoom below the grid and xAxis labels (top offset + grid height + ~30px for axis labels)
     const defaultSliderDataZoom = {
       type: 'slider',
       start: 0,
@@ -454,6 +445,26 @@ const _buildTimelineOption = function (data, config, tmpChartInstance, tmpChart)
       }
       return { ...userDataZoom, filterMode: 'none' };
     });
+  }
+
+  // Compute canvas height to fit all declared elements exactly.
+  // When dataZoom is present, the bottommost element is the slider:
+  //   its top = gridTop + resolvedGridHeight + 30 (axis label gap)
+  //   eCharts default slider height = 30px; add 10px bottom margin
+  // Without dataZoom, gridBottom already reserves space for axis labels below the grid.
+  if (computedOption.dataZoom && computedOption.dataZoom.some(dz => dz.type === 'slider' || !dz.type)) {
+    const sliderTop = gridTop + resolvedGridHeight + 30;
+    const sliderHeight = computedOption.dataZoom.reduce((maxBottom, dz) => {
+      if (dz.type === 'slider' || !dz.type) {
+        const dzTop = resolvePixelValue(dz.top, sliderTop);
+        const dzHeight = resolvePixelValue(dz.height, 30);
+        return Math.max(maxBottom, dzTop + dzHeight);
+      }
+      return maxBottom;
+    }, 0);
+    tmpChart['visualizationHeight'] = sliderHeight + 10;
+  } else {
+    tmpChart['visualizationHeight'] = gridTop + resolvedGridHeight + gridBottom;
   }
 
   // Ensure xAxis property overwrite
@@ -533,7 +544,7 @@ const _buildTimelineOption = function (data, config, tmpChartInstance, tmpChart)
   computedOption.series = [{
     id: 'timelineData',
     type: 'custom',
-    renderItem: splitByHour ? renderItemForHour : renderItemLogic,
+    renderItem: splitByHour ? makeRenderItemForHour(bandHeight, processedData) : makeRenderItemLogic(bandHeight),
     encode: {
       x: [computedDimensions[configStartTimeDataIndexBinding], computedDimensions[configEndTimeDataIndexBinding]], //start_time, end_time
       y: computedDimensions[configLegendsDataIndexBinding], //category

--- a/appserver/static/visualizations/hman/src/reflow/index.js
+++ b/appserver/static/visualizations/hman/src/reflow/index.js
@@ -1,4 +1,29 @@
 const echarts = require('echarts');
+
+function attachResizeListener(element, config) {
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.attributeName === 'class') {
+        const isResizing = element.classList.contains('ui-resizable-resizing');
+        const target = mutation.target;
+        if (!isResizing) {
+          if(target.getBoundingClientRect().height < config.theChartHeight){
+            target.style.overflowY = 'auto';
+            target.style.overflowX = 'hidden';
+          } else {
+            target.style.overflowY = 'hidden';
+            target.style.overflowX = 'hidden';
+          }
+        }
+      }
+    });
+  });
+  observer.observe(element, { 
+    attributes: true, 
+    attributeFilter: ['class'] 
+  });
+}
+
 // Override to respond to re-sizing events
 const _reflow = function () {
   var myChart = echarts.getInstanceByDom(this.el);
@@ -7,13 +32,13 @@ const _reflow = function () {
     const currentChartEntry = this.scopedVariables['_renderedEchartsArray'].find(o => o.instanceByDom === myChart);
     if(currentChartEntry && currentChartEntry['visualizationType'] === 'timeline') {
       const theChartHolder = myChart.getDom();
-      theChartHolder.parentElement.style.height = `${currentChartEntry['visualizationHeight']}px`;
-      const resizablePanel = theChartHolder.closest('.shared-reportvisualizer.ui-resizable');
-      if (resizablePanel) {
-        resizablePanel.style.overflowY = resizablePanel.clientHeight < currentChartEntry['visualizationHeight'] ? 'scroll' : 'hidden';
+      const scopedSplunkEchartsPanel = theChartHolder.parentElement.parentElement.parentElement.parentElement.parentElement;
+      const theChartHeight = currentChartEntry['visualizationHeight'] || myChart.getHeight();
+      attachResizeListener(scopedSplunkEchartsPanel, { theChartHeight });
+      if (hasProperty) {
+        myChart.resize({ height: theChartHeight });
       }
-    }
-    if (hasProperty) {
+    } else if (hasProperty) {
       myChart.resize();
     }
   }

--- a/appserver/static/visualizations/hman/src/reflow/index.js
+++ b/appserver/static/visualizations/hman/src/reflow/index.js
@@ -1,46 +1,56 @@
 const echarts = require('echarts');
 
-function attachResizeListener(element, config) {
+// Toggle vertical scrolling on the Splunk panel depending on whether the timeline canvas
+// is taller than the panel. Skipped while the user is actively dragging the resize handle.
+function applyPanelOverflow(panelEl, chartHeight) {
+  if (!panelEl || panelEl.classList.contains('ui-resizable-resizing')) { return; }
+  panelEl.style.overflowX = 'hidden';
+  panelEl.style.overflowY = panelEl.getBoundingClientRect().height < chartHeight ? 'auto' : 'hidden';
+}
+
+function attachResizeListener(element, getChartHeight) {
   const observer = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
       if (mutation.attributeName === 'class') {
-        const isResizing = element.classList.contains('ui-resizable-resizing');
-        const target = mutation.target;
-        if (!isResizing) {
-          if(target.getBoundingClientRect().height < config.theChartHeight){
-            target.style.overflowY = 'auto';
-            target.style.overflowX = 'hidden';
-          } else {
-            target.style.overflowY = 'hidden';
-            target.style.overflowX = 'hidden';
-          }
-        }
+        applyPanelOverflow(mutation.target, getChartHeight());
       }
     });
   });
-  observer.observe(element, { 
-    attributes: true, 
-    attributeFilter: ['class'] 
+  observer.observe(element, {
+    attributes: true,
+    attributeFilter: ['class']
   });
+  return observer;
 }
 
 // Override to respond to re-sizing events
 const _reflow = function () {
   var myChart = echarts.getInstanceByDom(this.el);
-  if (myChart != null) {
-    let hasProperty = Object.prototype.hasOwnProperty.call(myChart, "resize");
-    const currentChartEntry = this.scopedVariables['_renderedEchartsArray'].find(o => o.instanceByDom === myChart);
-    if(currentChartEntry && currentChartEntry['visualizationType'] === 'timeline') {
-      const theChartHolder = myChart.getDom();
-      const scopedSplunkEchartsPanel = theChartHolder.parentElement.parentElement.parentElement.parentElement.parentElement;
-      const theChartHeight = currentChartEntry['visualizationHeight'] || myChart.getHeight();
-      attachResizeListener(scopedSplunkEchartsPanel, { theChartHeight });
-      if (hasProperty) {
-        myChart.resize({ height: theChartHeight });
-      }
-    } else if (hasProperty) {
-      myChart.resize();
+  if (myChart == null) { return; }
+  const hasResize = Object.prototype.hasOwnProperty.call(myChart, "resize");
+  const currentChartEntry = this.scopedVariables['_renderedEchartsArray'].find(o => o.instanceByDom === myChart);
+  if (currentChartEntry && currentChartEntry['visualizationType'] === 'timeline') {
+    const theChartHolder = myChart.getDom();
+    const scopedSplunkEchartsPanel = theChartHolder.parentElement.parentElement.parentElement.parentElement.parentElement;
+    const self = this;
+    // Read the height live from whichever timeline is currently rendered, so the height changes
+    // pushed by dashboard filters (which rebuild the chart through updateView, not reflow) are honoured.
+    const getLiveChartHeight = function () {
+      const liveChart = echarts.getInstanceByDom(self.el);
+      const liveEntry = self.scopedVariables['_renderedEchartsArray'].find(o => o.instanceByDom === liveChart);
+      return (liveEntry && liveEntry['visualizationHeight']) || (liveChart && liveChart.getHeight()) || 0;
+    };
+    const theChartHeight = getLiveChartHeight();
+    if (this.scopedVariables['_timelineResizeObserver']) {
+      this.scopedVariables['_timelineResizeObserver'].disconnect();
     }
+    this.scopedVariables['_timelineResizeObserver'] = attachResizeListener(scopedSplunkEchartsPanel, getLiveChartHeight);
+    if (hasResize) {
+      myChart.resize({ height: theChartHeight });
+    }
+    applyPanelOverflow(scopedSplunkEchartsPanel, theChartHeight);
+  } else if (hasResize) {
+    myChart.resize();
   }
 }
 module.exports = _reflow;

--- a/appserver/static/visualizations/hman/src/timelineLayoutUtils/index.js
+++ b/appserver/static/visualizations/hman/src/timelineLayoutUtils/index.js
@@ -1,0 +1,23 @@
+function parsePixelValue(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmedValue = value.trim();
+    if (/^\d+(\.\d+)?px$/.test(trimmedValue) || /^\d+(\.\d+)?$/.test(trimmedValue)) {
+      return Number.parseFloat(trimmedValue);
+    }
+  }
+
+  return 0;
+}
+
+function resolvePixelValue(value, fallbackValue) {
+  const parsedValue = parsePixelValue(value);
+  return parsedValue > 0 ? parsedValue : fallbackValue;
+}
+
+module.exports = {
+  resolvePixelValue,
+};

--- a/appserver/static/visualizations/hman/src/updateView/index.js
+++ b/appserver/static/visualizations/hman/src/updateView/index.js
@@ -1,6 +1,5 @@
 const echarts = require('echarts');
 const SplunkVisualizationUtils = require('api/SplunkVisualizationUtils');
-//const cloneDeep = require('lodash.clonedeep');
 
 // Implement updateView to render a visualization.
 // This function is called whenever search results are updated or the visualization format changes. It handles visualization rendering
@@ -45,19 +44,10 @@ const _updateView = function (data, config) {
   const currentTheme = SplunkVisualizationUtils.getCurrentTheme();
   const echartsTheme = currentTheme;
   if (echartProps.dataType.toLowerCase() === 'timeline') {
-    const ns = this.getPropertyNamespaceInfo().propertyNamespace;
-    const preBandHeight = parseInt(config[ns + 'timeline_bandHeight']) || 32;
-    const preBandGap = parseInt(config[ns + 'timeline_bandGap']) || 8;
-    const preCategories = [...new Set(data.rows.map(r => r[2]))];
-    const preHeight = (preBandHeight + preBandGap) * preCategories.length + 210;
-    this.el.parentElement.style.height = `${preHeight}px`;
-    const resizablePanel = this.el.closest('.shared-reportvisualizer.ui-resizable');
-    if (resizablePanel) {
-      resizablePanel.style.overflowY = resizablePanel.clientHeight < preHeight ? 'scroll' : 'hidden';
-    }
-    tmpChart['instanceByDom'] = echarts.init(this.el, echartsTheme, { height: preHeight });
     tmpChart['_applyBgColor'] = true;
-  } else {
+  }
+  // For timeline, echarts.init is deferred until after buildTimelineOption computes the correct height
+  if (echartProps.dataType.toLowerCase() !== 'timeline') {
     tmpChart['instanceByDom'] = echarts.init(this.el, echartsTheme);
   }
   if(typeof dedicatedMqttClient !== 'undefined') {
@@ -77,7 +67,14 @@ const _updateView = function (data, config) {
   } else if (echartProps.dataType.toLowerCase() == "simpleboxplot") {
     option = this._buildSimpleBoxplotOption(data, config);
   } else if (echartProps.dataType.toLowerCase() == "timeline") {
+    // Init with height:1 as placeholder — we will resize to the correct height after build
+    tmpChart['instanceByDom'] = echarts.init(this.el, echartsTheme, { height: 1 });
     option = this._buildTimelineOption(data, config, tmpChart['instanceByDom'], tmpChart);
+    if (tmpChart['visualizationHeight']) {
+      const contentHeight = tmpChart['visualizationHeight'];
+      this.el.style.height = `${contentHeight}px`;
+      tmpChart['instanceByDom'].resize({ height: contentHeight });
+    }
   } else if (echartProps.dataType.toLowerCase() == "hourlytimeline") {
     option = this._buildHourlyTimelineOption(data, config, tmpChart['instanceByDom']);
   }
@@ -115,11 +112,10 @@ const _updateView = function (data, config) {
     }
   }
 
-  // Overwrite default eCharts v6 legend position
-  if (typeof option.legend === 'undefined' || (typeof option.legend.top === 'undefined' && typeof option.legend.bottom === 'undefined')) {
-    if (typeof option.legend === 'undefined') {
-      option.legend = {};
-    }
+  // Hide legend if not specified; otherwise fix default eCharts v6 position
+  if (typeof option.legend === 'undefined') {
+    option.legend = { show: false };
+  } else if (typeof option.legend.top === 'undefined' && typeof option.legend.bottom === 'undefined') {
     option.legend.top = 0;
   }
 

--- a/appserver/static/visualizations/hman/src/updateView/index.js
+++ b/appserver/static/visualizations/hman/src/updateView/index.js
@@ -122,6 +122,12 @@ const _updateView = function (data, config) {
   tmpChart['instanceByDom'].setOption(option);
   tmpChart['_option'] = option;
 
+  // A data change (e.g. dashboard filters feeding more rows) rebuilds the chart here but does not
+  // trigger reflow, so re-run it to re-apply the timeline canvas height and the panel scroll state.
+  if (tmpChart['visualizationType'] === 'timeline') {
+    try { this.reflow(); } catch (e) { console.log('reflow after timeline render failed', e); }
+  }
+
   if (tmpChart['_applyBgColor']) {
     const resizablePanelForBg = this.el.closest('.shared-reportvisualizer.ui-resizable');
     if (resizablePanelForBg) {

--- a/appserver/static/visualizations/hman/webpack.config.js
+++ b/appserver/static/visualizations/hman/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
         modules: [`${__dirname}/node_modules`]
     },
     mode: 'development',
+    devtool: 'source-map',
     output: {
         path: `${__dirname}`,
         filename: 'visualization.js',

--- a/default/app.conf
+++ b/default/app.conf
@@ -4,10 +4,10 @@
 
 [id]
 name = visualization_toolbox
-version = 0.4.7
+version = 0.4.8-rc1
 
 [install]
-build = 20260507
+build = 0.4.8-rc1
 state = enabled
 is_configured = 0
 
@@ -23,7 +23,7 @@ company = hman
 [launcher]
 author = hman
 description = Visualization Toolbox for Splunk Enterprise powered by the Apache ECharts library.
-version = 0.4.7
+version = 0.4.8-rc1
 
 [package]
 check_for_updates = 1

--- a/default/app.conf
+++ b/default/app.conf
@@ -4,7 +4,7 @@
 
 [id]
 name = visualization_toolbox
-version = 0.4.8-rc3
+version = 0.4.8
 
 [install]
 build = 2026051201
@@ -23,7 +23,7 @@ company = hman
 [launcher]
 author = hman
 description = Visualization Toolbox for Splunk Enterprise powered by the Apache ECharts library.
-version = 0.4.8-rc3
+version = 0.4.8
 
 [package]
 check_for_updates = 1

--- a/default/app.conf
+++ b/default/app.conf
@@ -4,10 +4,10 @@
 
 [id]
 name = visualization_toolbox
-version = 0.4.8-rc1
+version = 0.4.8-rc2
 
 [install]
-build = 0.4.8-rc1
+build = 20260512
 state = enabled
 is_configured = 0
 
@@ -23,7 +23,7 @@ company = hman
 [launcher]
 author = hman
 description = Visualization Toolbox for Splunk Enterprise powered by the Apache ECharts library.
-version = 0.4.8-rc1
+version = 0.4.8-rc2
 
 [package]
 check_for_updates = 1

--- a/default/app.conf
+++ b/default/app.conf
@@ -4,10 +4,10 @@
 
 [id]
 name = visualization_toolbox
-version = 0.4.7-rc6
+version = 0.4.7
 
 [install]
-build = 20260413
+build = 20260507
 state = enabled
 is_configured = 0
 
@@ -23,7 +23,7 @@ company = hman
 [launcher]
 author = hman
 description = Visualization Toolbox for Splunk Enterprise powered by the Apache ECharts library.
-version = 0.4.7-rc6
+version = 0.4.7
 
 [package]
 check_for_updates = 1

--- a/default/app.conf
+++ b/default/app.conf
@@ -4,10 +4,10 @@
 
 [id]
 name = visualization_toolbox
-version = 0.4.6
+version = 0.4.7-rc6
 
 [install]
-build = 0.4.6
+build = 20260413
 state = enabled
 is_configured = 0
 
@@ -23,7 +23,7 @@ company = hman
 [launcher]
 author = hman
 description = Visualization Toolbox for Splunk Enterprise powered by the Apache ECharts library.
-version = 0.4.6
+version = 0.4.7-rc6
 
 [package]
 check_for_updates = 1

--- a/default/app.conf
+++ b/default/app.conf
@@ -4,10 +4,10 @@
 
 [id]
 name = visualization_toolbox
-version = 0.4.8-rc2
+version = 0.4.8-rc3
 
 [install]
-build = 20260512
+build = 2026051201
 state = enabled
 is_configured = 0
 
@@ -23,7 +23,7 @@ company = hman
 [launcher]
 author = hman
 description = Visualization Toolbox for Splunk Enterprise powered by the Apache ECharts library.
-version = 0.4.8-rc2
+version = 0.4.8-rc3
 
 [package]
 check_for_updates = 1


### PR DESCRIPTION
## Summary

Bundles the v0.4.8 release work for the `hman` timeline visualization with the GitHub Actions workflow updates needed to keep CI green on the runner-side Node 24 transition.

### Timeline visualization (`5e9c390`)
- New `timelineLayoutUtils` module and timeline scrolling support
- Tuned drawing band height / band gap; eliminated cross-instance contamination of these values when multiple timelines render on the same dashboard
- `updateView` now sets `this.el.style.height` to the data-driven content height; `reflow` re-applies the stored `visualizationHeight` instead of letting `myChart.resize()` snap back to the Splunk panel's fixed container height on filter changes
- Added `getMeasuredViewportHeight()` to trust live `clientHeight` when it diverges meaningfully from chart content height
- Updated legend show/hide condition for eCharts v6 default position
- Replaced deprecated `styleEmphasis` / `style` usage in `renderItemLogic`
- Versions bumped to across `app.conf`, `app.manifest`, `package.json`; `app.conf` `build` switched to integer for Splunk static-asset cache busting

### CI workflows (`17ab9c0`)
- Dropped Node 20 from the matrix; Node 22 only
- Pinned `actions/checkout@v4.2.2`, `actions/setup-node@v4.4.0`, `actions/setup-python@v5.6.0` (minimum patch versions that ship a Node 24 runtime)
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow level to opt into Node 24 ahead of the June 2026 default flip
- Removed npm cache from `setup-node` and the `npm install npm@latest -g` step — both were responsible for the `MODULE_NOT_FOUND: 'promise-retry'` failures, since the cache restored a corrupt npm install and the upgrade step couldn't bootstrap itself through it